### PR TITLE
Added new check for generated images that now looks at the image manifest rather than at the workflow. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,10 @@
+# Configuration files
 utilities/swarm-envs.sh
 utilities/secrets
 
+# Testing files
+test.sh
+
+# Environment files
 *.yml
 .env


### PR DESCRIPTION
This is more consistant as it means that there will always be a value to check against when looking for new images. Solves issue of workflow not starting when check is made if new commit is pushed.

Also added a timer that gives and estimate of how long it took to deploy the changes.